### PR TITLE
Update to recent versions of SBT, Lift and Scala 2.13

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,7 +14,7 @@ resolvers ++= Seq(
 
 enablePlugins(JettyPlugin)
 
-unmanagedResourceDirectories in Test += baseDirectory.value / "src/main/webapp"
+Test / unmanagedResourceDirectories += baseDirectory.value / "src/main/webapp"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
@@ -27,4 +27,4 @@ libraryDependencies ++= {
   )
 }
 
-scalacOptions in Test ++= Seq("-Yrangepos")
+Test / scalacOptions ++= Seq("-Yrangepos")

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name = my-lift-app
 package = com.myco
 organization = com.myco
-lift_version = 3.3.0
-scala_version = 2.12.6
+lift_version = 3.5.0
+scala_version = 2.13.14
 verbatim = *.gif

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,5 +2,5 @@ name = my-lift-app
 package = com.myco
 organization = com.myco
 lift_version = 3.5.0
-scala_version = 2.13.14
+scala_version = 2.13.4
 verbatim = *.gif

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.10.1


### PR DESCRIPTION
Seems that with more modern JDK and the old SBT version defined in the project property, the build might fail. Updated to recent versions. Also the syntax in sbt config was indicated with deprecation warnings.